### PR TITLE
Fixing CI tool with builds for Linux and OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,45 @@
-language: cpp
-sudo: false
-
-compiler:
-  - clang
-  - gcc
-
-addons:
-  apt:
-    sources:
-    - llvm-toolchain-precise
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-5
-    - g++-5
-    - clang-3.7
-    - llvm-3.7
-
 env:
   global:
-    - GCC_VERSION=5
-    - LLVM_VERSION=3.7
-    - CFLAGS="-O3 -Wall -Wextra"
-    - CPPFLAGS="-O3 -Wall -Wextra"
-    - CXXFLAGS="-O3 -Wall -Wextra"
     - PREFIX="/tmp/usr"
 
-os:
-  - linux
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      language: generic
+      sudo: required
+      compiler: gcc
+      env: CFLAGS="-O3 -Wall -Wextra" CXXFLAGS="-O3 -Wall -Wextra"
+    - os: linux
+      dist: trusty
+      language: generic
+      sudo: required
+      compiler: gcc
+      env: CFLAGS="-O3 -Wall -Wextra" CXXFLAGS="-O3 -Wall -Wextra" CONFIGURE="--target=i686-linux-gnu"
+    - os: linux
+      dist: trusty
+      language: generic
+      sudo: required
+      compiler: clang
+      env: CFLAGS="-O3 -Wall -Wextra" CXXFLAGS="-O3 -Wall -Wextra"
+    - os: linux
+      dist: trusty
+      language: generic
+      sudo: required
+      compiler: clang
+      env: CFLAGS="-O3 -Wall -Wextra" CXXFLAGS="-O3 -Wall -Wextra" CONFIGURE="--target=i686-linux-gnu"
+    - os: osx
+      compiler: gcc
+      env: CFLAGS="-O3 -Wall -Wextra" CXXFLAGS="-O3 -Wall -Wextra"
+      osx_image: xcode7.3
+    - os: osx
+      compiler: clang
+      env: CFLAGS="-O3 -Wall -Wextra" CXXFLAGS="-O3 -Wall -Wextra"
+      osx_image: xcode7.3
 
 notifications:
   email: false
-  irc: 
+  irc:
     channels:
       - "chat.freenode.net#ArchC"
     on_success: change
@@ -46,19 +55,20 @@ notifications:
 before_install:
   - echo $LANG
   - echo $LC_ALL
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CONFIGURE" == "--target=i686-linux-gnu" ] ; then sudo apt-get install -y gcc-multilib g++-multilib; fi
   - uname -a
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then lsb_release -a ; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++" ]; then export CC=/usr/bin/gcc-${GCC_VERSION} ; export CXX=/usr/bin/g++-${GCC_VERSION}; $CXX --version ; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "clang++" ]; then export PATH=/usr/lib/llvm-${LLVM_VERSION}/bin/:$PATH ; clang++ --version ; fi
+  - env
   - export PATH="${PREFIX}/bin:${PATH}"
   - export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}"
   - export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
   - git clone --depth 1 https://github.com/ArchC/SystemC.git /tmp/SystemC
-  - pushd /tmp/SystemC ; autoreconf -vif ; ./configure --prefix=${PREFIX} ; make install -j3 ; popd
+  - pushd /tmp/SystemC ; autoreconf -vif ; ./configure --prefix=${PREFIX}; make install -j3 ; popd
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then git clone --depth 1 git://git.fedorahosted.org/git/elfutils.git /tmp/elfutils; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pushd /tmp/elfutils ; autoreconf -vif ; ./configure --prefix=${PREFIX} --enable-maintainer-mode; make install -j3 ; popd; fi
 
 install:
   - autoreconf -vif
-  - ./configure --prefix=$PREFIX --disable-hlt
+  - ./configure --prefix=$PREFIX $CONFIGURE
   - make -j3
 
 before_script:
@@ -85,5 +95,3 @@ deployment:
 
 
 after_deployment:
-
-

--- a/README.md
+++ b/README.md
@@ -14,10 +14,24 @@ License
    directory of the ArchC source tree, are provided under the GNU LGPL
    license. See the [Copying Lib](COPYING.LIB) file for details on this license.
 
+
+Requirements
+------------
+
+1. GNU autotools (m4 autoconf automake libtool)
+
+2. SystemC  
+   http://www.accellera.org/downloads/standards/systemc  
+   https://github.com/ArchC/SystemC.git
+
+3. elfutils (libelf and libdw) - Optional for High Level Trace feature  
+   https://fedorahosted.org/elfutils/  
+   git://git.fedorahosted.org/git/elfutils.git
+
 Build
 ------------
 ArchC package uses the GNU autotools framework to build the source
-files and install them into the host system. .
+files and install them into the host system.
 
 1.
 ```bash

--- a/configure.ac
+++ b/configure.ac
@@ -120,12 +120,11 @@ AC_ARG_ENABLE(hlt,
               AS_HELP_STRING([--disable-hlt], [Disable High Level Trace feature]),
               [disable_hlt=yes],[])
 
-AS_IF([ test "$disable_hlt" != "yes" ],
-      [ AC_CHECK_HEADER([elfutils/libdwfl.h],[],[AC_MSG_ERROR(["Please, install libdw-dev"])])], 
-      [])
-
-
-AM_CONDITIONAL([HLT_SUPPORT], [ ! test "$disable_hlt" = "yes" ])
+PKG_CHECK_MODULES(LIBELF, [libelf >= 0.166 libdw >= 0.166],
+                  [have_libelf=yes],
+                  [have_libelf=no])
+AM_CONDITIONAL(HAVE_LIBELF, test "x$have_libelf" = "xyes")
+AM_CONDITIONAL([HLT_SUPPORT], [ test "x$disable_hlt" != "xyes" -a "x$have_libelf" = "xyes" ])
 
 #CC="clang-3.5 -std=c11"
 #CXX="clang++-3.5 -std=c++11"

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ AC_DISABLE_SHARED
 
 # Checks for programs.
 AC_PROG_CXX
+AX_CXX_COMPILE_STDCXX_11
 AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_MAKE_SET
@@ -25,6 +26,7 @@ AC_PROG_LIBTOOL
 AC_PROG_LEX
 AC_PROG_YACC
 AC_PROG_INSTALL
+
 
 # pkg-config
 PKG_PROG_PKG_CONFIG
@@ -125,11 +127,6 @@ PKG_CHECK_MODULES(LIBELF, [libelf >= 0.166 libdw >= 0.166],
                   [have_libelf=no])
 AM_CONDITIONAL(HAVE_LIBELF, test "x$have_libelf" = "xyes")
 AM_CONDITIONAL([HLT_SUPPORT], [ test "x$disable_hlt" != "xyes" -a "x$have_libelf" = "xyes" ])
-
-#CC="clang-3.5 -std=c11"
-#CXX="clang++-3.5 -std=c++11"
-CC="gcc -std=gnu99"
-CXX="g++ -std=c++11"
 
 # Sets global flags
 CFLAGS="$CFLAGS -Wall"

--- a/src/aclib/ac_utils/Makefile.am
+++ b/src/aclib/ac_utils/Makefile.am
@@ -1,7 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 
 ## Includes
-AM_CPPFLAGS = -std=c++11 -I. -I$(top_srcdir)/src/aclib/ac_decoder -I$(top_srcdir)/src/aclib/ac_gdb -I$(top_srcdir)/src/aclib/ac_storage -I$(top_srcdir)/src/aclib/ac_syscall -I$(top_srcdir)/src/aclib/ac_core -I$(top_srcdir)/src/aclib/ac_rtld @SYSTEMC_CFLAGS@ -ldw -lelf
+AM_CPPFLAGS = -std=c++11 -I. -I$(top_srcdir)/src/aclib/ac_decoder -I$(top_srcdir)/src/aclib/ac_gdb -I$(top_srcdir)/src/aclib/ac_storage -I$(top_srcdir)/src/aclib/ac_syscall -I$(top_srcdir)/src/aclib/ac_core -I$(top_srcdir)/src/aclib/ac_rtld @SYSTEMC_CFLAGS@
 
 
 ## The ArchC library
@@ -9,15 +9,12 @@ noinst_LTLIBRARIES = libacutils.la
 
 ## ArchC library includes
 
-if HLT_SUPPORT
-include_HEADERS = ac_debug_model.H elf32-tiny.h archc.H ac_utils.H ac_log.H ac_msgbuf.H ac_hltrace.H
-else
 include_HEADERS = ac_debug_model.H elf32-tiny.h archc.H ac_utils.H ac_log.H ac_msgbuf.H
-endif
+libacutils_la_SOURCES = ac_utils.cpp
+
 
 if HLT_SUPPORT
-libacutils_la_SOURCES = ac_utils.cpp ac_hltrace.cpp
-else
-libacutils_la_SOURCES = ac_utils.cpp 
+include_HEADERS +=  ac_hltrace.H
+libacutils_la_SOURCES += ac_hltrace.cpp
+AM_CPPFLAGS += @LIBELF_CFLAGS@
 endif
-


### PR DESCRIPTION
Use only Ubuntu Trusty (beta) and Apple OS X.
- Fetch and install SystemC from ArchC's GitHub.
- Fetch and install elfutils from official repository for Linux builds.
- Compile the ArchC

Required:
- Use pkg-config to check libelf and libdw (include in early versions of them).
- Don't force use gcc with c++11 or c99. Use M4 macros to check the support.
