### PR TITLE
Update acbingen.sh to build binutils 2.24

### DIFF
--- a/src/acbinutils/Makefile.am
+++ b/src/acbinutils/Makefile.am
@@ -37,7 +37,7 @@ FILES_TO_PATCH = \
 	opcodes/disassemble.c \
 	ld/configure.tgt \
 	ld/Makefile.in \
-  	include/dis-asm.h
+	include/dis-asm.h
 
 FILES_TO_COPY = \
 	gas/config/tc-xxxxx.c \
@@ -122,6 +122,7 @@ install-data-hook:
 	for file in $(FILES_TO_COPY); do \
 	  cp -f $(srcdir)/$(BINUTILS_ROOT)/$${file} $(pkgdatadir)/$(BINUTILS_ROOT)/$${file}; \
 	done
+	cp binutils/gas/config/tc-xxxxx.c $(pkgdatadir)/$(BINUTILS_ROOT)/gas/config/tc-xxxxx.c
 	for directory in $(GDB_ROOT) $(GDB_TREE); do \
 	  mkdir -p $(pkgdatadir)/$${directory}; \
 	done;	

--- a/src/acbinutils/acbingen.sh.in
+++ b/src/acbinutils/acbingen.sh.in
@@ -449,9 +449,10 @@ if [ ! -z ${BINUTILS_INST_DIR} ]; then
     cd ..
     mkdir -p build_gdb
     cd build_gdb
-    $GDB_DIR/configure --target=${ARCH_NAME}-elf --prefix=`pwd` --bindir=${BINUTILS_INST_DIR}
+    $GDB_DIR/configure --without-docdir --target=${ARCH_NAME}-elf --prefix=`pwd` --bindir=${BINUTILS_INST_DIR}
     [ $? -ne 0 ] && exit $?
-    make 
+    echo "MAKEINFO = :" >> Makefile
+    make
     [ $? -ne 0 ] && exit $?
     make install
     [ $? -ne 0 ] && exit $?

--- a/src/acbinutils/acbingen.sh.in
+++ b/src/acbinutils/acbingen.sh.in
@@ -437,7 +437,7 @@ if [ ! -z ${BINUTILS_INST_DIR} ]; then
   if [ ! -z ${BINUTILS_DIR} ]; then
     mkdir -p build
     cd build
-    $BINUTILS_DIR/configure --target=${ARCH_NAME}-elf --prefix=`pwd` --bindir=${BINUTILS_INST_DIR}
+    $BINUTILS_DIR/configure --disable-werror --target=${ARCH_NAME}-elf --prefix=`pwd` --bindir=${BINUTILS_INST_DIR}
     [ $? -ne 0 ] && exit $?
     make 
     [ $? -ne 0 ] && exit $?

--- a/src/acbinutils/acbingen.sh.in
+++ b/src/acbinutils/acbingen.sh.in
@@ -16,6 +16,7 @@ Options:
              <model-file> without the extension)
   -i<dir>    build and install the binary utilities in directory <dir>
              NOTE: <dir> -MUST- be an absolute path
+  -j         parallelize build when running make
   -c         only create the files, do not copy to binutils tree
   -f         force patching binutils and gdb tree even if an architecture
              with the same name already exists
@@ -32,6 +33,7 @@ Try \`$me -h for more information."
 
 ARCH_NAME=""
 CREATE_ONLY=0
+PARALLEL_BUILD=0
 BINUTILS_INST_DIR=""
 PATCH_BINUTILS=1  #1 means to patch, 0 otherwise
 PATCH_GDB=1  #1 means to patch, 0 otherwise
@@ -39,11 +41,12 @@ FORCE_PATCH=0
 TEMP_DIR="acbingenbuilddir"
 
 # Parse command line
-while getopts  ":hvfca:i:" flag
+while getopts  ":hvfjca:i:" flag
 do
   case $flag in
     h) echo "$usage"; exit 0 ;;
     v) echo "$version" ; exit 0 ;;
+    j) PARALLEL_BUILD=1 ;;
     c) CREATE_ONLY=1 ;;
     f) FORCE_PATCH=1 ;;
     a) ARCH_NAME="$OPTARG" ;;
@@ -439,7 +442,11 @@ if [ ! -z ${BINUTILS_INST_DIR} ]; then
     cd build
     $BINUTILS_DIR/configure --disable-werror --target=${ARCH_NAME}-elf --prefix=`pwd` --bindir=${BINUTILS_INST_DIR}
     [ $? -ne 0 ] && exit $?
-    make 
+    if [ "$PARALLEL_BUILD" -ne 0 ]; then
+        make -j
+    else
+        make
+    fi
     [ $? -ne 0 ] && exit $?
     make install
     [ $? -ne 0 ] && exit $?
@@ -452,7 +459,11 @@ if [ ! -z ${BINUTILS_INST_DIR} ]; then
     $GDB_DIR/configure --without-docdir --target=${ARCH_NAME}-elf --prefix=`pwd` --bindir=${BINUTILS_INST_DIR}
     [ $? -ne 0 ] && exit $?
     echo "MAKEINFO = :" >> Makefile
-    make
+    if [ "$PARALLEL_BUILD" -ne 0 ]; then
+        make -j
+    else
+        make
+    fi
     [ $? -ne 0 ] && exit $?
     make install
     [ $? -ne 0 ] && exit $?


### PR DESCRIPTION
This pull request updates acbingen.sh to use -disable-werror when building binutils 2.24 (otherwise it will never compile) and fixes an issue that used to happen if you build ArchC in an out-of-tree folder. In this case, the file tc-xxxxx.c was not being copied to the installation directory upon "make install".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/archc/archc/48)

<!-- Reviewable:end -->
