### PR TITLE
Group of fixes, including the TLM2 Payload memory leaks

### DIFF
--- a/src/aclib/ac_storage/ac_mem.H
+++ b/src/aclib/ac_storage/ac_mem.H
@@ -75,10 +75,10 @@ public:
   void read(ac_ptr buf, uint32_t address,
 		   int wordsize, int n_words);
 
-  void write(ac_ptr buf, uint32_t address,
+  void write(const ac_ptr buf, uint32_t address,
 		    int wordsize);
 
-  void write(ac_ptr buf, uint32_t address,
+  void write(const ac_ptr buf, uint32_t address,
 		    int wordsize, int n_words);
 
 
@@ -89,10 +89,10 @@ public:
   void read(ac_ptr buf, uint32_t address,
          int wordsize, int n_words,sc_core::sc_time &time_info,unsigned int procId=0);
 
-  void write(ac_ptr buf, uint32_t address,
+  void write(const ac_ptr buf, uint32_t address,
           int wordsize,sc_core::sc_time &time_info,unsigned int procId=0);
 
-  void write(ac_ptr buf, uint32_t address,
+  void write(const ac_ptr buf, uint32_t address,
           int wordsize, int n_words,sc_core::sc_time &time_info,unsigned int procId=0);
 
 

--- a/src/aclib/ac_storage/ac_mem.cpp
+++ b/src/aclib/ac_storage/ac_mem.cpp
@@ -109,7 +109,7 @@ void ac_mem::read(ac_ptr buf, uint32_t address,
   }
 }
 
-void ac_mem::write(ac_ptr buf, uint32_t address,
+void ac_mem::write(const ac_ptr buf, uint32_t address,
 		       int wordsize) {
   switch (wordsize) {
   case 8: { // unsigned char
@@ -133,7 +133,7 @@ void ac_mem::write(ac_ptr buf, uint32_t address,
   }
 }
 
-void ac_mem::write(ac_ptr buf, uint32_t address,
+void ac_mem::write(const ac_ptr buf, uint32_t address,
 		       int wordsize, int n_words) {
   switch (wordsize) {
   case 8: { // unsigned char
@@ -177,14 +177,14 @@ void ac_mem::read(ac_ptr buf, uint32_t address,
   this->read(buf,address,wordsize,n_words);
 }
 
-void ac_mem::write(ac_ptr buf, uint32_t address,
+void ac_mem::write(const ac_ptr buf, uint32_t address,
            int wordsize,sc_core::sc_time &time_info,unsigned int procId) {
 
 
   this->write(buf,address,wordsize);
 }
 
-void ac_mem::write(ac_ptr buf, uint32_t address,
+void ac_mem::write(const ac_ptr buf, uint32_t address,
            int wordsize, int n_words,sc_core::sc_time &time_info,unsigned int procId) {
 
   this->write(buf,address,wordsize,n_words);

--- a/src/aclib/ac_storage/ac_memport.H
+++ b/src/aclib/ac_storage/ac_memport.H
@@ -433,7 +433,7 @@ public:
 #endif
 
   //!Method to provide the name of the device.
-  inline char* get_name() {
+  inline const char* get_name() {
     return "";
   }
 

--- a/src/aclib/ac_syscall/ac_syscall.H
+++ b/src/aclib/ac_syscall/ac_syscall.H
@@ -1015,7 +1015,7 @@ int ac_syscall<ac_word, ac_Hword>::process_syscall(int syscall) {
     int ret;
     unsigned whence = get_int(4);
     if (offset_high == 0) {
-      uint64_t ret_off;
+      int64_t ret_off;
       // Assume 64-bit offsets for all systems
       ret_off = ::lseek(fd, offset_low, whence);
       if (ret_off >= 0) {

--- a/src/aclib/ac_tlm/ac_tlm2_nb_port.cpp
+++ b/src/aclib/ac_tlm/ac_tlm2_nb_port.cpp
@@ -56,16 +56,6 @@ tlm::tlm_sync_enum  ac_tlm2_nb_port::nb_transport_bw(ac_tlm2_payload &payload, t
 	printf("\n\nNB_TRANSPORT_BW --> Processor is receiving a package");
 	#endif
 
-	/******/
- 	payload_global = new ac_tlm2_payload();
- 	
-
-	unsigned char* data_pointer = payload.get_data_ptr();		 
-	payload_global->set_data_ptr(data_pointer);
-    
-
- 	payload_global->deep_copy_from(payload);
-	
  	#ifdef debugTLM2
 	printf("\nAC_TLM2_NB_PORT NB_TRANSPORT_BW: command-->%d  data-->%d payload_global data->%d address-->%ld",payload_global->get_command(),*data_pointer,*(payload_global->get_data_ptr()),addr);        
 	printf("\nNotifying a event in BW TRANSPORT");
@@ -133,9 +123,6 @@ void ac_tlm2_nb_port::read(ac_ptr buf, uint32_t address, int wordsize,sc_core::s
 		printf("\nAC_TLM2_NB_PORT READ ERROR");
 		exit(0);
 	}
-
-	/**** TENTATIVA PARA EVITAR MEMORY LEAK*/
-	delete payload_global;
 
 
 	wait(this->wake_up);
@@ -233,9 +220,6 @@ void ac_tlm2_nb_port::read(ac_ptr buf, uint32_t address,
 				printf("\nAC_TLM2_NB_PORT n_words READ ERROR");
 				exit(0);
 			}
-			
-			/**** TENTATIVA PARA EVITAR MEMORY LEAK*/
-			delete payload_global;
 
 			wait(this->wake_up);
 			
@@ -264,9 +248,6 @@ void ac_tlm2_nb_port::read(ac_ptr buf, uint32_t address,
 				printf("\nAC_TLM2_NB_PORT n_words READ ERROR");
 				exit(0);
 			}
-
-			/**** TENTATIVA PARA EVITAR MEMORY LEAK*/
-			delete payload_global;
 
 	
 			wait(this->wake_up);
@@ -297,10 +278,6 @@ void ac_tlm2_nb_port::read(ac_ptr buf, uint32_t address,
 				exit(0);
 			}
 	
-
-			/**** TENTATIVA PARA EVITAR MEMORY LEAK*/
-			delete payload_global;
-
 
 			wait(this->wake_up);
 
@@ -378,9 +355,6 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
     printf("\n\nAC_TLM2_NB_PORT WRITE is waiting for wake_up event");
     #endif
 
-    /*****/
-    delete payload_global;
-
     wait(this->wake_up);
 
     
@@ -406,13 +380,7 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
 	exit(0);
     }
 
-	/*****/
-    delete payload_global;
-
     wait(this->wake_up);
-    
-
-	
 
     break;
   case 16:
@@ -429,10 +397,6 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
 	exit(0);
     }
 	
-
-	/*****/
-    delete payload_global;
-
     wait(this->wake_up);
     
     payload_global->set_command(tlm::TLM_WRITE_COMMAND);
@@ -456,10 +420,7 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
 	exit(0);
     } 
     
-    /*****/
-    delete payload_global;
     wait(this->wake_up);
-    
 
     break;
  
@@ -487,11 +448,7 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
 	exit(0);
     } 
 
-
-   /*****/
-    delete payload_global;
     wait(this->wake_up);
-	
 
     break;
  

--- a/src/aclib/ac_tlm/ac_tlm2_nb_port.cpp
+++ b/src/aclib/ac_tlm/ac_tlm2_nb_port.cpp
@@ -124,6 +124,7 @@ void ac_tlm2_nb_port::read(ac_ptr buf, uint32_t address, int wordsize,sc_core::s
 	/**********
 	To guarantee that there are no extensions in the payload
 	**********/
+	payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
 	payload_global->free_all_extensions();	
 
 	status = LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info);
@@ -225,6 +226,7 @@ void ac_tlm2_nb_port::read(ac_ptr buf, uint32_t address,
 			payload_global->set_data_length(sizeof(uint8_t));
 			payload_global->set_data_ptr(p);
 
+			payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
 			status = LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info); 
 			if(status != tlm::TLM_UPDATED)
 			{
@@ -255,6 +257,7 @@ void ac_tlm2_nb_port::read(ac_ptr buf, uint32_t address,
 			payload_global->set_data_length(sizeof(uint16_t));
 			payload_global->set_data_ptr(p);
 
+			payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
 			status = LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info); 
 			if(status != tlm::TLM_UPDATED)
 			{
@@ -286,6 +289,7 @@ void ac_tlm2_nb_port::read(ac_ptr buf, uint32_t address,
 			payload_global->set_data_length(sizeof(uint32_t));
 		        payload_global->set_data_ptr(p);
 
+			payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
 			status = LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info); 
 			if(status != tlm::TLM_UPDATED)
 			{
@@ -362,6 +366,7 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
     payload_global->set_data_length(sizeof(uint8_t));
     payload_global->set_data_ptr(p);
     
+    payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
     status = LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info); 
     if(status != tlm::TLM_UPDATED)
     {
@@ -393,6 +398,7 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
 	**********/
 	payload_global->free_all_extensions();	
 
+    payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
     status =  LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info); 
     if(status != tlm::TLM_UPDATED)
     {
@@ -415,6 +421,7 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
     payload_global->set_data_length(sizeof(uint16_t));
     payload_global->set_data_ptr(p);
 
+    payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
     status = LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info); 
     if(status != tlm::TLM_UPDATED)
     {
@@ -441,6 +448,7 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
 	payload_global->free_all_extensions();	
 
 
+    payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
     status = LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info); 
     if(status != tlm::TLM_UPDATED)
     {
@@ -470,6 +478,7 @@ void ac_tlm2_nb_port::write(ac_ptr buf, uint32_t address, int wordsize,sc_core::
 	**********/
 	payload_global->free_all_extensions();	
 	
+    payload_global->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
     status = LOCAL_init_socket->nb_transport_fw(*payload_global, phase, time_info); 
 
     if(status != tlm::TLM_UPDATED)


### PR DESCRIPTION
TLM2 payload reuses must be marked again as an incomplete request.
And the payload's deletion should wait for the answer.

Storage writes use const ac_ptr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/archc/archc/52)
<!-- Reviewable:end -->
