### PR TITLE
[acsim] adding -scsv flag for enabling csv stats export on model file…

### DIFF
--- a/src/aclib/ac_stats/ac_instruction_stats.H
+++ b/src/aclib/ac_stats/ac_instruction_stats.H
@@ -87,6 +87,8 @@ class ac_instruction_stats : public ac_basic_stats<EN>,
 
     /// Printing method from ac_printable_stats.
     void print_stats(ostream& os);
+    void print_stats_csv(FILE* file);
+
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -114,6 +116,15 @@ void ac_instruction_stats<EN>::print_stats(ostream& os)
     os << "     " << stat_name_[i] << " : " << stat_[i] << endl;
   }
 }
+
+template <class EN>
+void ac_instruction_stats<EN>::print_stats_csv(FILE* file)
+{
+  for (int i = 0; i < number_of_stats_; i++) {
+    fprintf(file, "%s, %lld\n", instr_name_.c_str(), stat_[i]);
+  }
+}
+
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/src/aclib/ac_stats/ac_printable_stats.H
+++ b/src/aclib/ac_stats/ac_printable_stats.H
@@ -61,6 +61,7 @@ using std::ostream;
 class ac_printable_stats {
   public:
     virtual void print_stats(ostream& os) = 0;
+    virtual void print_stats_csv(FILE* file) = 0;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/aclib/ac_stats/ac_processor_stats.H
+++ b/src/aclib/ac_stats/ac_processor_stats.H
@@ -85,6 +85,7 @@ class ac_processor_stats : public ac_basic_stats<EN>, public ac_stats_base {
 
     /// Printing method from ac_stats_base.
     void print_stats(ostream& os);
+    void print_stats_csv(FILE* file);
 
     /// Method that adds an ac_instruction_stats to the corresponding list.
     void add_instr_stats(ac_printable_stats* is);
@@ -121,6 +122,29 @@ void ac_processor_stats<EN>::print_stats(ostream& os)
       it++) {
     (*it)->print_stats(os);
   }
+
+}
+
+template <class EN>
+void ac_processor_stats<EN>::print_stats_csv(FILE* file){
+  FILE *output;
+  string filename = "";
+  filename.append(proc_name_);
+  filename.append("_lastrun_stats.csv");
+
+  if ( !(output = fopen( filename.c_str(), "w"))){
+    perror("ArchC could not open stats csv output file");
+    exit(1);
+  }
+  fprintf(output, "INSTRUCTION, USES\n");
+  list<ac_printable_stats*>::iterator it;
+  for (it = list_of_instr_stats_.begin();
+      it != list_of_instr_stats_.end();
+      it++) {
+    (*it)->print_stats_csv(output);
+  }
+
+  fclose(output);
 }
 
 template <class EN>

--- a/src/aclib/ac_stats/ac_stats_base.H
+++ b/src/aclib/ac_stats/ac_stats_base.H
@@ -71,9 +71,11 @@ class ac_stats_base : public ac_printable_stats {
 
     /// Prints info of all instances.
     static void print_all_stats(ostream& os);
+    static void print_all_stats_csv();
 
     /// Prints info of this ac_stats_instance.
     virtual void print_stats(ostream& os) = 0;
+    virtual void print_stats_csv(FILE* file) = 0;
 
     /// Virtual destructor.
     virtual ~ac_stats_base();

--- a/src/aclib/ac_stats/ac_stats_base.cpp
+++ b/src/aclib/ac_stats/ac_stats_base.cpp
@@ -77,6 +77,14 @@ void ac_stats_base::print_all_stats(ostream& os)
   }
 }
 
+void ac_stats_base::print_all_stats_csv()
+{
+  list<ac_stats_base*>::iterator it;
+  for (it = list_of_stats_.begin(); it != list_of_stats_.end(); it++) {
+    (*it)->print_stats_csv(NULL);
+  }
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 // Destructors

--- a/src/acsim/acsim.c
+++ b/src/acsim/acsim.c
@@ -3536,7 +3536,7 @@ void CreateMakefile(){
 
   fprintf( output, "model_clean:\n");
   //fprintf( output, "\trm -f $(ACSRCS) $(ACHEAD) $(ACINCS) $(ACFILESHEAD)  *.tmpl loader.ac \n\n");
-  fprintf( output, "\trm -f $(ACSRCS) $(ACHEAD) $(ACINCS) *.tmpl loader.ac \n\n");
+  fprintf( output, "\trm -f $(ACSRCS) $(ACHEAD) $(ACINCS) %s*.tmpl loader.ac \n\n", ACStatsFlag ? "$(TARGET)_stats.cpp " : "");
 
   fprintf( output, "sim_clean: clean model_clean\n\n");
 

--- a/src/acsim/acsim.c
+++ b/src/acsim/acsim.c
@@ -73,6 +73,7 @@ int  ACDecCacheFlag=1;                          //!<Indicates whether the simula
 int  ACDelayFlag=0;                             //!<Indicates whether delay option is turned on or not
 int  ACDDecoderFlag=0;                          //!<Indicates whether decoder structures are dumped or not
 int  ACStatsFlag=0;                             //!<Indicates whether statistics collection is enable or not
+int  ACCSVStatsFlag = 0;                        //!< Indicates whether statistics collection to csv is enable or not
 int  ACVerboseFlag=0;                           //!<Indicates whether verbose option is turned on or not
 int  ACGDBIntegrationFlag=0;                    //!<Indicates whether gdb support will be included in the simulator
 int  ACWaitFlag=1;                              //!<Indicates whether the instruction execution thread issues a wait() call or not
@@ -128,6 +129,7 @@ struct option_map option_map[] = {
   {"--help"            , "-h"  ,"Display this help message."       , 0},
   {"--no-dec-cache"    , "-ndc","Disable cache of decoded instructions." ,"o"},
   {"--stats"           , "-s"  ,"Enable statistics collection during simulation." ,"o"},
+  {"--stats-csv"         , "-scsv"          , "Enable statistics collection during simulation and output to file $ARCH_lastrun_stats.csv." ,"o"},
   {"--verbose"         , "-vb" ,"Display update logs for storage devices during simulation.", "o"},
   {"--version"         , "-vrs","Display ACSIM version.", 0},
   {"--gdb-integration" , "-gdb","Enable support for debbuging programs running on the simulator.", 0},
@@ -328,6 +330,11 @@ int main(int argc, char** argv) {
               break;
             case OPStats:
               ACStatsFlag = 1;
+              ACOptions_p += sprintf( ACOptions_p, "%s ", argv[0]);
+              break;
+            case OPCSVStats:
+              ACStatsFlag = 1;
+              ACCSVStatsFlag = 1;
               ACOptions_p += sprintf( ACOptions_p, "%s ", argv[0]);
               break;
             case OPVerbose:
@@ -1089,6 +1096,9 @@ void CreateParmHeader() {
 
   if( ACStatsFlag )
     fprintf( output, "#define  AC_STATS \t //!< Indicates that statistics collection is turned on.\n");
+
+  if( ACCSVStatsFlag )
+    fprintf( output, "#define  AC_CSV_STATS \t //!< Indicates that statistics collection is turned on and directed do csv file.\n");
 
   if( HaveMemHier )
     fprintf( output, "#define  AC_MEM_HIERARCHY \t //!< Indicates that a memory hierarchy was declared.\n\n");
@@ -2637,9 +2647,15 @@ void CreateMainTmpl() {
   fprintf(output, "%s%s_proc1.PrintStat();\n", INDENT[1], project_name);
   fprintf(output, "%scerr << endl;\n\n", INDENT[1]);
 
+
+
   fprintf( output, "#ifdef AC_STATS\n");
+  fprintf( output, "%s#ifdef AC_CSV_STATS\n", INDENT[1]);
+  fprintf( output, "%sac_stats_base::print_all_stats_csv();\n",INDENT[2]);
+  fprintf( output, "%s#else\n", INDENT[1]);
   fprintf( output, "%sac_stats_base::print_all_stats(std::cerr);\n",
-           INDENT[1]);
+           INDENT[2]);
+  fprintf( output, "%s#endif \n\n", INDENT[1]);
   fprintf( output, "#endif \n\n");
 
   fprintf( output, "#ifdef AC_DEBUG\n");

--- a/src/acsim/acsim.h
+++ b/src/acsim/acsim.h
@@ -111,6 +111,7 @@ enum _ac_cmd_options {
   OPHelp,
   OPDecCache,
   OPStats,
+  OPCSVStats,
   OPVerbose,
   OPVersion,
   OPGDBIntegration,


### PR DESCRIPTION
…s generation. Generated file is named arch_lastrun_stats.csv

Generated .csv file is like:
INSTRUCTION, USES
ADD, 0
SUB, 0
SLL, 0
SLT, 0
SLTU, 0
XOR, 0
SRL, 0
SRA, 0
OR, 0
AND, 0
...

file name example for riscv: riscv_lastrun_stats.csv

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/archc/archc/56)
<!-- Reviewable:end -->
